### PR TITLE
fix: redis type hints for lsp

### DIFF
--- a/backend/src/rs/rs.py
+++ b/backend/src/rs/rs.py
@@ -1,4 +1,5 @@
-from redis import asyncio as asyncredis
+from typing import Set
+import redis
 from models.stroke import Stroke
 import os
 
@@ -8,14 +9,15 @@ PORT = int(os.getenv("REDIS_PORT", 6379))
 
 class StrokeStore:
     def __init__(self, hosturl: str = HOST, portno: int = PORT):
-        self.client = asyncredis.Redis(host=hosturl, port=portno)
-    
+        self.client = redis.Redis(host=hosturl, port=portno)
+
     async def save_stroke(self, board_id: int, data: Stroke):
-        await self.client.sadd(str(board_id), data.model_dump_json())
-    
+        self.client.sadd(str(board_id), data.model_dump_json())
+
     async def delete_stroke(self, board_id: int, data: Stroke):
-        await self.client.srem(str(board_id), data.model_dump_json())
-    
+        self.client.srem(str(board_id), data.model_dump_json())
+
     async def load_stroke_history(self, board_id: int):
-        mems = await self.client.smembers(str(board_id))
+        mems = self.client.smembers(str(board_id))
+        assert isinstance(mems, Set)
         return {mem.decode("utf-8") for mem in mems}


### PR DESCRIPTION
# Changes

- Moved away from the async type for now
- Fixes errors showing up when dealing with the possibly awaitable types
- For more info: https://github.com/redis/redis-py/issues/2399

# Risks

- None

# Tested?

- Tested locally